### PR TITLE
ci: :passport_control: releasing requires `contents: write` permissions

### DIFF
--- a/.github/workflows/release-project.yml
+++ b/.github/workflows/release-project.yml
@@ -11,6 +11,9 @@ permissions: read-all
 jobs:
   release-package:
     # This job outputs env variables `previous_version` and `current_version`.
+    # The workflow needs write permissions for `GITHUB_TOKEN` to create a release.
+    permissions:
+      contents: write
     uses: seedcase-project/.github/.github/workflows/reusable-release-project.yml@main
     with:
       app-id: ${{ vars.UPDATE_VERSION_APP_ID }}


### PR DESCRIPTION
# Description

I forgot this permission setting. It is needed to release to GitHub.

No review needed.
