### PR TITLE
build: :hammer: fixes website build from contributor script

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,7 @@
 project:
   type: seedcase-theme
+  pre-render:
+    - sh ./tools/get-contributors.sh seedcase-project/template-website
   render:
     # Don't render anything in the template directory.
     - "!template/"

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@
     just --list --unsorted
 
 @_checks: check-spelling check-commits
-@_tests: test
 @_builds: build-contributors build-website build-readme
 # Test if it is or isn't a Seedcase website
 @_tests: (test "true") (test "false")

--- a/tools/get-contributors.sh
+++ b/tools/get-contributors.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Get a list of contributors to this repository and save it to
-# _contributors.qmd.tmp file. It also:
+# _contributors.qmd file (overwritten if it exists). It also:
 #
 # - Formats users into Markdown links to their GitHub profiles.
 # - Removes any usernames with the word "bot" in them.
 # - Removes the trailing comma from the list.
 repo_spec=${1}
-echo "These are the people who have contributed by submitting changes through pull requests :tada:\n\n" > _contributors.qmd.tmp
+echo "These are the people who have contributed by submitting changes through pull requests :tada:\n\n" > _contributors.qmd
 gh api \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -15,4 +15,4 @@ gh api \
   --template '{{range .}} [\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
   grep -v "\[bot\]" | \
   tr '\n' ', ' | \
-  sed -e 's/,$//' >> _contributors.qmd.tmp
+  sed -e 's/,$//' >> _contributors.qmd


### PR DESCRIPTION
# Description

After using `{{< include ... >}}`, Quarto needs that file to exist first. So I added an empty `_contributors.qmd` file and moved the pre-render step into the `_quarto.yml` file.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
