### PR TITLE
ci: :construction_worker: improve speed of CI by removing `zsh` dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install justfile and zsh
-        run: sudo apt install -y just zsh
+      - name: Install justfile
+        run: sudo apt install -y just
 
       - name: Set Git user
         run: |

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ check-commits:
   number_of_commits=$(git rev-list --count HEAD ^main)
   if [[ ${branch_name} != "main" && ${number_of_commits} -gt 0 ]]
   then
+    # If issue happens, try `uv tool update-shell`
     uvx --from commitizen cz check --rev-range main..HEAD
   else
     echo "On 'main' or current branch doesn't have any commits."

--- a/justfile
+++ b/justfile
@@ -33,14 +33,14 @@ update-template:
 
 # Check the commit messages on the current branch that are not on the main branch
 check-commits:
-  #!/bin/zsh
+  #!/usr/bin/env bash
   branch_name=$(git rev-parse --abbrev-ref HEAD)
   number_of_commits=$(git rev-list --count HEAD ^main)
   if [[ ${branch_name} != "main" && ${number_of_commits} -gt 0 ]]
   then
     uvx --from commitizen cz check --rev-range main..HEAD
   else
-    echo "On `main` or current branch doesn't have any commits."
+    echo "On 'main' or current branch doesn't have any commits."
   fi
 
 # Check for spelling errors in files
@@ -49,7 +49,7 @@ check-spelling:
 
 # Test and check that a data package can be created from the template
 test is_seedcase_website:
-  #!/bin/zsh
+  #!/usr/bin/env bash
   test_name="test-website"
   test_dir="$(pwd)/_temp/{{ is_seedcase_website }}/$test_name"
   template_dir="$(pwd)"
@@ -93,7 +93,6 @@ test is_seedcase_website:
 
 # Clean up any leftover and temporary build files
 cleanup:
-  #!/bin/zsh
   rm -rf _temp
 
 # Build the website using Quarto


### PR DESCRIPTION
# Description

Installing zsh on GitHub takes like 45 sec, which isn't needed. So just switch to the built-in bash.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
