### PR TITLE
build: :pencil2: forgot to remove `.tmp` from includes shortcode

### DIFF
--- a/README.qmd
+++ b/README.qmd
@@ -40,7 +40,7 @@ By participating in this project you agree to abide by its terms.
 <!-- TODO: Unhide after more contributors -->
 ### Contributors
 
-{{< include /_contributors.qmd.tmp >}}
+{{< include /_contributors.qmd >}}
 :::
 
 ## Licensing

--- a/index.qmd
+++ b/index.qmd
@@ -61,5 +61,5 @@ share your ideas or contribute code. Your input makes us better!
 <!-- TODO: Unhide after more contributors -->
 ### Contributors
 
-{{< include /_contributors.qmd.tmp >}}
+{{< include /_contributors.qmd >}}
 :::

--- a/justfile
+++ b/justfile
@@ -110,4 +110,4 @@ build-readme:
 
 # Generate a Quarto include file with the contributors
 build-contributors:
-  sh ./tools/get-contributors.sh seedcase-project/template-workshop
+  sh ./tools/get-contributors.sh seedcase-project/template-website


### PR DESCRIPTION
# Description

Website is failing to build because I forgot to remove the `.tmp` from the includes. This fixes it.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
