### PR TITLE
fix: :lock: use `read-all` permissions for workflow at top level

### DIFF
--- a/template/.github/workflows/add-to-project.yml.jinja
+++ b/template/.github/workflows/add-to-project.yml.jinja
@@ -11,12 +11,14 @@ on:
       - reopened
       - opened
 
-permissions:
-  pull-requests: write
+# Limit token permissions for security
+permissions: read-all
 
 jobs:
   add-to-project:
     uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
+    permissions:
+      pull-requests: write
     with:
       app-id: {{ '${{ vars.ADD_TO_BOARD_APP_ID }}' }}
       board-number: {{ github_board_number }}


### PR DESCRIPTION
# Description

Forgot to update this workflow with the correct security practices.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
