### PR TITLE
refactor: :recycle: revise so `github_repo` is name of folder

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path | realpath | dirname }}"
+  default: "{{ _copier_conf.dst_path | realpath | basename }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -9,7 +9,7 @@ _tasks:
 # Message to show after generating or regenerating the project successfully
 _message_after_copy: |
 
-  Your project "{{ website_abbrev }}" has been created successfully!
+  Your project "{{ github_repo }}" has been created successfully!
 
   See the [guide](https://template-website.seedcase-project.org/docs/guide) for more detail
   on the next steps. Briefly:
@@ -87,12 +87,13 @@ review_team:
     {{ "@%s/developers" % github_user if github_user else "" }}
 
 # Configurations not asked
-github_org:
-  type: str
-  default: "{{ website_github_repo.split('/')[0] if website_github_repo else '' }}"
-  when: false
 
 github_repo:
   type: str
-  default: "{{ website_github_repo.split('/')[1] if website_github_repo else '' }}"
+  default: "{{ _copier_conf.dst_path | basename }}"
+  when: false
+
+github_repo_spec:
+  type: str
+  default: "{{ github_user }}/{{ github_repo }}"
   when: false

--- a/copier.yaml
+++ b/copier.yaml
@@ -58,7 +58,7 @@ website_abbrev:
   help: "What is the abbreviated name of the website? This could be the name of your GitHub repository and should be a short, lowercase name without spaces or special characters. For example, 'new-website'."
   default: "{{ _copier_conf.dst_path | basename }}"
   validator: |
-    {% if not (website_abbrev | regex_search('^[\w.-_]+$')) %}
+    {% if website_abbrev and not (website_abbrev | regex_search('^[\w.-_]+$')) %}
     The abbreviation must only contain alphanumeric characters and `_`, `-`, or `.`.
     {% endif %}
 

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path.split('/') | last }}"
+  default: "{{ _copier_conf.dst_path.parts[-1] }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -53,23 +53,9 @@ seedcase_website:
   default: false
   help: "Is this website part of the Seedcase Project? If not, the theme will not be applied."
 
-website_abbrev:
+github_user:
   type: str
-  help: "What is the abbreviated name of the website? This could be the name of your GitHub repository and should be a short, lowercase name without spaces or special characters. For example, 'new-website'."
-  default: "{{ _copier_conf.dst_path | basename }}"
-  validator: |
-    {% if website_abbrev and not (website_abbrev | regex_search('^[\w.-_]+$')) %}
-    The abbreviation must only contain alphanumeric characters and `_`, `-`, or `.`.
-    {% endif %}
-
-website_github_repo:
-  type: str
-  help: "What is or will be the GitHub repository spec for the website?"
-  placeholder: "user/repo"
-  validator: |
-    {% if website_github_repo and not (website_github_repo | regex_search('^[\w.-]+\/[\w.-]+$')) %}
-    Must be in the format `user/repo` and contain only alphanumeric characters and `_`, `-`, or `.`.
-    {% endif %}
+  help: "What is the name of the GitHub user or organization where the website repository will be or is stored?"
 
 hosting_provider:
   type: str
@@ -98,7 +84,7 @@ review_team:
   type: str
   help: What GitHub team is responsible for reviewing pull requests?
   default: >-
-    {{ "@%s/developers" % website_github_repo.split('/')[0] if website_github_repo else "" }}
+    {{ "@%s/developers" % github_user if github_user else "" }}
 
 # Configurations not asked
 github_org:

--- a/copier.yaml
+++ b/copier.yaml
@@ -17,7 +17,7 @@ _message_after_copy: |
   1. Change directory to the project root:
 
     ``` bash
-    cd {{ _copier_conf.dst_path }}
+    cd {{ _copier_conf.dst_path | realpath }}
     ```
 
   2. Install the pre-commit hooks, add (called "update" here) the Quarto extension,
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path.append('/') | dirname | basename }}"
+  default: "{{ _copier_conf.dst_path | realpath | dirname }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path | basename }}"
+  default: "{{ _copier_conf.dst_path | dirname | basename }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path | dirname }}"
+  default: "{{ _copier_conf.dst_path.split('/') | last }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path | dirname | basename }}"
+  default: "{{ _copier_conf.dst_path | dirname }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ _copier_conf.dst_path.parts[-1] }}"
+  default: "{{ list(filter(None, _copier_conf.dst_path.parts))[-1] }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -90,7 +90,7 @@ review_team:
 
 github_repo:
   type: str
-  default: "{{ list(filter(None, _copier_conf.dst_path.parts))[-1] }}"
+  default: "{{ _copier_conf.dst_path.append('/') | dirname | basename }}"
   when: false
 
 github_repo_spec:

--- a/copier.yaml
+++ b/copier.yaml
@@ -57,6 +57,10 @@ website_abbrev:
   type: str
   help: "What is the abbreviated name of the website? This could be the name of your GitHub repository and should be a short, lowercase name without spaces or special characters. For example, 'new-website'."
   default: "{{ _copier_conf.dst_path | basename }}"
+  validator: |
+    {% if not (website_abbrev | regex_search('^[\w.-_]+$')) %}
+    The abbreviation must only contain alphanumeric characters and `_`, `-`, or `.`.
+    {% endif %}
 
 website_github_repo:
   type: str

--- a/docs/guide.qmd
+++ b/docs/guide.qmd
@@ -42,8 +42,14 @@ new website. Then run the following command:
 
 ``` bash
 # Copy into the current directory, which is the "."
-uvx copier copy --trust gh:seedcase-project/template-website .
+uvx copier copy --trust gh:seedcase-project/template-website new-website
 ```
+
+Where `new-website` the name of the new folder you will create from the
+template. The template assumes that the name of your new folder will
+also be the name of the GitHub repository for the website. So the new
+folder name should be short, lowercase name without spaces or special
+characters.
 
 ::: callout-caution
 This template runs some post-copy commands using your terminal. In order
@@ -63,11 +69,13 @@ existing website. This will add all the template's files and
 configurations to the existing website.
 
 ``` bash
-uvx copier copy --trust gh:seedcase-project/template-website .
+uvx copier copy --trust gh:seedcase-project/template-website new-website
 ```
 
-It will go through a series of prompts, as in the case of creating a new
-website, including asking if you want to overwrite existing files.
+See the comment above in the "creating a new website" section about naming
+of the new website folder. It will go through a series of prompts, as in
+the case of creating a new website, including asking if you want to
+overwrite existing files.
 
 ::: callout-note
 To use the `copy` command, the website needs to be tracked by Git and in
@@ -151,8 +159,8 @@ provides a consistent look and feel across all Seedcase Project
 websites. It's called `update-quarto-theme` here since you can use this
 command to keep the theme updated.
 
-Then to use the theme, you need to update the `_quarto.yml` file
-by adding the following lines to the `project` and `format` sections:
+Then to use the theme, you need to update the `_quarto.yml` file by
+adding the following lines to the `project` and `format` sections:
 
 ``` yaml
 project:

--- a/docs/guide.qmd
+++ b/docs/guide.qmd
@@ -41,7 +41,6 @@ open a Terminal and move into the directory where you want to create the
 new website. Then run the following command:
 
 ``` bash
-# Copy into the current directory, which is the "."
 uvx copier copy --trust gh:seedcase-project/template-website new-website
 ```
 
@@ -73,7 +72,7 @@ uvx copier copy --trust gh:seedcase-project/template-website new-website
 ```
 
 See the comment above in the "creating a new website" section about naming
-of the new website folder. It will go through a series of prompts, as in
+the new website folder. It will go through a series of prompts, as in
 the case of creating a new website, including asking if you want to
 overwrite existing files.
 

--- a/template/.zenodo.json.jinja
+++ b/template/.zenodo.json.jinja
@@ -11,7 +11,7 @@
   "access_right": "open",
   "related_identifiers": [
     {
-      "identifier": "https://github.com/{{ website_github_repo }}",
+      "identifier": "https://github.com/{{ github_repo_spec }}",
       "relation": "isSupplementTo",
       "resource_type": "other"
     }

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -4,7 +4,7 @@
 
 The easiest way to contribute is to report issues or bugs that you might
 find while reading through the website. You can do this by creating a
-[new](https://github.com/{{ website_github_repo }}/issues/new/choose)
+[new](https://github.com/{{ github_repo_spec }}/issues/new/choose)
 issue on our GitHub repository.
 
 ## Adding or modifying content :pencil2:
@@ -16,7 +16,7 @@ details on how we work and develop. It is a regularly evolving document,
 so is at various states of completion.
 {%- endif %}
 
-To contribute to `{{ website_abbrev }}`, you first need to install
+To contribute to `{{ github_repo }}`, you first need to install
 [uv](https://docs.astral.sh/uv/) and
 [justfile](https://just.systems/man/en/packages.html). We use uv and
 justfile to manage our project, such as to run checks and test the

--- a/template/_metadata.yml.jinja
+++ b/template/_metadata.yml.jinja
@@ -1,3 +1,3 @@
 gh:
   repo: {{ github_repo }}
-  org: {{ github_org }}
+  org: {{ github_user }}

--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -11,7 +11,7 @@ website:
   # TODO: Set the Netlify custom domain URL
   site-url: ""
   {%- endif %}
-  repo-url: "https://github.com/{{ website_github_repo }}"
+  repo-url: "https://github.com/{{ github_repo_spec }}"
   navbar:
     {% if seedcase_website -%}
     logo: "_extensions/seedcase-project/seedcase-theme/logos/seedcase-logo.svg"
@@ -27,7 +27,7 @@ website:
         href: index.qmd
     tools:
       - icon: github
-        href: "https://github.com/{{ website_github_repo }}"
+        href: "https://github.com/{{ github_repo_spec }}"
         aria-label: "GitHub icon: Source repository"
       {% if seedcase_website -%}
       - icon: house

--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -6,7 +6,7 @@ website:
   # TODO: Set the title of the website
   title: ""
   {% if hosting_provider == "gh-pages" -%}
-  site-url: "https://{{ github_org }}.github.io/{{ github_repo }}/"
+  site-url: "https://{{ github_user }}.github.io/{{ github_repo }}/"
   {%- elif hosting_provider == "netlify" -%}
   # TODO: Set the Netlify custom domain URL
   site-url: ""

--- a/template/includes/site-counter.html.jinja
+++ b/template/includes/site-counter.html.jinja
@@ -1,3 +1,3 @@
 <!-- TODO: Create this site on the goatcounter settings page -->
-<script data-goatcounter="https://{{ github_org }}-{{ github_repo }}.goatcounter.com/count" async
+<script data-goatcounter="https://{{ github_user }}-{{ github_repo }}.goatcounter.com/count" async
   src="//gc.zgo.at/count.js"></script>

--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -58,7 +58,7 @@ build-readme:
 
 # Generate a Quarto include file with the contributors
 build-contributors:
-  sh ./tools/get-contributors.sh {{ website_github_repo }}
+  sh ./tools/get-contributors.sh {{ github_repo_spec }}
 
 # Check for and apply updates from the template
 update-from-template:

--- a/template/{% if hosting_provider == "netlify" %}_publish.yml{% endif %}.jinja
+++ b/template/{% if hosting_provider == "netlify" %}_publish.yml{% endif %}.jinja
@@ -2,4 +2,4 @@
   netlify:
     # TODO: Include correct ID and URL
     - id: ""
-      url: "https://{{ github_org }}-{{ github_repo }}.netlify.app"
+      url: "https://{{ github_user }}-{{ github_repo }}.netlify.app"

--- a/test-template.sh
+++ b/test-template.sh
@@ -40,6 +40,7 @@ copy () {
     --data author_family_name="Last" \
     --data github_board_number="14" \
     --skip-tasks \
+    --overwrite \
     --trust
 }
 

--- a/test-template.sh
+++ b/test-template.sh
@@ -41,7 +41,6 @@ copy () {
     --data github_board_number="14" \
     --overwrite \
     --skip-tasks \
-    --overwrite \
     --trust
 }
 

--- a/test-template.sh
+++ b/test-template.sh
@@ -34,7 +34,7 @@ copy () {
     --defaults \
     --data seedcase_website=$is_seedcase_website \
     --data hosting_provider=$hosting_provider \
-    --data website_github_repo="fake/repo" \
+    --data github_user="fake" \
     --data review_team="@fake/team" \
     --data author_given_name="First" \
     --data author_family_name="Last" \


### PR DESCRIPTION
# Description

I removed the use of `website_abbrev` (it was only used once anyway). Also found a bug. We need to use `realpath` for `dst_path` otherwise it will use `.` if the template destination path is the same as the working directory. I also split it so the `github_repo` was determined from `dst_path` (which requires use of the `realpath` first).

Closes #20

This PR needs an in-depth review.

## Checklist

- [x] Ran `just run-all`
