### PR TITLE
refactor: :memo: use bash code chunk style for post-copy message

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -45,7 +45,9 @@ _message_after_copy: |
 
   5. List and complete all TODO items in the repository:
 
-    $ just list-todos
+    ``` bash
+    just list-todos
+    ```
 
 # Questions
 is_seedcase_website:


### PR DESCRIPTION
# Description

This just makes it a bit nicer looking. The `$` is always confusing to represent a terminal prompt is not the best choice when showing commands to run. (e.g. Not as easy to copy and paste).

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
