### PR TITLE
refactor: :wrench: don't use `echo: false` by default in Quarto config

### DIFF
--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -60,6 +60,3 @@ editor:
   markdown:
     wrap: 72
     canonical: true
-
-execute:
-  echo: false


### PR DESCRIPTION
# Description

A Quarto website's main purpose or benefit is to show code. So hiding it by default isn't ideal/fit for the purpose of Quarto. This remove it.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
