### PR TITLE
build: :fire: don't generate the contributors from `_quarto.yml`

### DIFF
--- a/_contributors.qmd
+++ b/_contributors.qmd
@@ -1,0 +1,4 @@
+These are the people who have contributed by submitting changes through pull requests :tada:
+
+
+ [\@lwjohnst86](https://github.com/lwjohnst86)

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,7 +1,5 @@
 project:
   type: seedcase-theme
-  pre-render:
-    - sh ./tools/get-contributors.sh seedcase-project/template-website
   render:
     # Don't render anything in the template directory.
     - "!template/"


### PR DESCRIPTION
# Description

Since we generate it locally and commit the contributors, it isn't necessary to do through the workflows.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
