### PR TITLE
refactor: :recycle: store `github_repo` into copier answer file

### DIFF
--- a/template/{{_copier_conf.answers_file}}.jinja
+++ b/template/{{_copier_conf.answers_file}}.jinja
@@ -1,2 +1,2 @@
-# Changes here will be overwritten by Copier
-{{ _copier_answers|to_nice_yaml -}}
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ dict(_copier_answers, github_repo=github_repo) | to_nice_yaml -}}


### PR DESCRIPTION
# Description

This variable data is needed for updating later on. Since `when: false` means that the data isn't stored by default in `.copiers-anwers.yml` file, we need to explicitly store it.

Closes #63

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
