### PR TITLE
fix: :bug: `github_repo` needs to be a question to store properly

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -59,6 +59,11 @@ github_user:
   type: str
   help: "What is the name of the GitHub user or organization where the website repository will be or is stored?"
 
+github_repo:
+  type: str
+  help: "What is the name of the GitHub repository where the website will be or is stored? We strongly recommend using the default given."
+  default: "{{ _folder_name }}"
+
 hosting_provider:
   type: str
   help: "What hosting provider will you use for the website?"
@@ -89,12 +94,6 @@ review_team:
     {{ "@%s/developers" % github_user if github_user else "" }}
 
 # Configurations not asked
-
-github_repo:
-  type: str
-  default: "{{ _copier_conf.dst_path | realpath | basename }}"
-  when: false
-
 github_repo_spec:
   type: str
   default: "{{ github_user }}/{{ github_repo }}"

--- a/template/{{_copier_conf.answers_file}}.jinja
+++ b/template/{{_copier_conf.answers_file}}.jinja
@@ -1,2 +1,2 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-{{ dict(_copier_answers, github_repo=github_repo) | to_nice_yaml -}}
+{{ _copier_answers | to_nice_yaml -}}


### PR DESCRIPTION
# Description

I found a bug with how copier does updating. Seems we can't use `dst_path` for `when: false` stored values, as it reverts to using the temporary location when running `copier update`. So this moves it up as an actual question to be stored in the answer file.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
