### PR TITLE
fix: :pencil2: value should be `isIdenticalTo` in `.zenodo.json`

### DIFF
--- a/template/.zenodo.json.jinja
+++ b/template/.zenodo.json.jinja
@@ -12,7 +12,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/{{ github_repo_spec }}",
-      "relation": "isSupplementTo",
+      "relation": "isIdenticalTo",
       "resource_type": "other"
     }
   ],


### PR DESCRIPTION
# Description

Since the repo is the exact copy that is on Zenodo.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
