### PR TITLE
refactor: :recycle: ignore other, non-relevant files when listing todos

### DIFF
--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -14,7 +14,12 @@ run-all: _checks _builds
 
 # List all TODO items in the repository
 list-todos:
-  grep -R -n --exclude="*.code-snippets" "TODO" *
+  grep -R -n \
+    --exclude="*.code-snippets" \
+    --exclude-dir=.quarto \
+    --exclude=justfile \
+    --exclude=_site \
+    "TODO" *
 
 {% if is_seedcase_website -%}
 # Update the Quarto seedcase-theme extension


### PR DESCRIPTION
# Description

We don't need to list TODOs in these locations, as they are temporary or are settings/configs.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
