### PR TITLE
test: :white_check_mark: no need to run `just` in the test templates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@9e48da27e184aa238fcb49f5db75469626d43adb # v2.1.9
-
       - name: Install justfile
         run: sudo apt install -y just
 

--- a/test-template.sh
+++ b/test-template.sh
@@ -73,7 +73,5 @@ echo "Testing copy for new projects when: 'is_seedcase_website'='$is_seedcase_we
     rm .cz.toml .copier-answers.yml &&
     git add . &&
     git commit --quiet -m "test: preparing to copy onto an existing website" &&
-    copy $template_dir $test_dir &&
-    # Checks and builds -----
-    just run-all
+    copy $template_dir $test_dir
 )


### PR DESCRIPTION
# Description

Running just after generating the test template makes the test run longer and don't really improve things (in my opinion). So I removed it. It also means we can cut down on the workflow by removing Quarto.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
