### PR TITLE
fix: 🐛 remove reflow-mode, default value works better

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -22,9 +22,6 @@ allow-lazy-continuation = false
 # Reflow text
 [MD013]
 reflow = true
-reflow-mode = "normalize"
-# Exclude code blocks from line length check
-# code-blocks = false
 
 # Fix tables and their separator row
 [MD060]

--- a/template/.rumdl.toml
+++ b/template/.rumdl.toml
@@ -22,9 +22,6 @@ allow-lazy-continuation = false
 # Reflow text
 [MD013]
 reflow = true
-reflow-mode = "normalize"
-# Exclude code blocks from line length check
-# code-blocks = false
 
 # Fix tables and their separator row
 [MD060]


### PR DESCRIPTION
# Description

I thought the "normalise" option for `reflow-mode` was a better option but I didn't understand the description correctly. The default option is the better working one.

Needs no review.

## Checklist

- [x] Ran `just run-all`
