### PR TITLE
refactor: :recycle: contributors listed on newlines

### DIFF
--- a/template/tools/get-contributors.sh
+++ b/template/tools/get-contributors.sh
@@ -14,7 +14,8 @@ contributors=$(gh api \
   --template '{{range .}} [\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
   grep -v "\[bot\]" | \
   tr '\n' ', ' | \
-  sed -e 's/,$/\n/'
+  sed -e 's/,$/\n/' | \
+  sed -e 's/,/,\n/g'
 )
 
 echo "The following people have contributed to this project by submitting pull requests :tada:\n\n${contributors}"

--- a/tools/get-contributors.sh
+++ b/tools/get-contributors.sh
@@ -14,7 +14,8 @@ contributors=$(gh api \
   --template '{{range .}} [\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
   grep -v "\[bot\]" | \
   tr '\n' ', ' | \
-  sed -e 's/,$/\n/'
+  sed -e 's/,$/\n/' | \
+  sed -e 's/,/,\n/g'
 )
 
 echo "The following people have contributed to this project by submitting pull requests :tada:\n\n${contributors}"


### PR DESCRIPTION
# Description

Running rumdl reformats to each new line, but the current script outputs to one line, which means this triggers a git change diff, which is annoying. This resolves that.

Needs no review.

## Checklist

- [x] Ran `just run-all`
