### PR TITLE
refactor: :recycle: ignore HTML when running typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,6 @@
 [files]
 extend-exclude = [
+  "*.html",
   "*.css",
   ".quarto/*",
   "_site/*",

--- a/template/.typos.toml
+++ b/template/.typos.toml
@@ -1,5 +1,6 @@
 [files]
 extend-exclude = [
+  "*.html",
   "*.css",
   ".quarto/*",
   "_site/*",


### PR DESCRIPTION
# Description

We don't need to check generated HTML files. Also is annoying if Quarto fails and a bunch of HTML files are left around, which typos will check still.

Needs no review.

## Checklist

- [x] Ran `just run-all`
