### PR TITLE
refactor: :fire: don't indent by 4 in Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,3 @@ max_line_length = 88
 # Have a bit shorter line length for text docs
 [*.{txt,md,qmd}]
 max_line_length = 72
-indent_size = 4

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -15,4 +15,3 @@ max_line_length = 88
 # Have a bit shorter line length for text docs
 [*.{txt,md,qmd}]
 max_line_length = 72
-indent_size = 4


### PR DESCRIPTION
# Description

After using rumdl, the default indent is 2, so this matches what rumdl uses.

Needs no review.

## Checklist

- [x] Ran `just run-all`
