### PR TITLE
refactor: :recycle: moved reusable workflow content into template itself

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,14 +14,40 @@ on:
 # Limit token permissions for security
 permissions: read-all
 
+env:
+  ADD_TO_BOARD_APP_ID: ${{ vars.ADD_TO_BOARD_APP_ID }}
+  BOARD_NUMBER: 24
+
 jobs:
   add-to-project:
-    uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    with:
-      board-number: 18
-      app-id: ${{ vars.ADD_TO_BOARD_APP_ID }}
-    secrets:
-      add-to-board-token: ${{ secrets.ADD_TO_BOARD }}
-      gh-token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ env.ADD_TO_BOARD_APP_ID }}
+          # TODO: Confirm this is set up for the repo.
+          private-key: ${{ secrets.ADD_TO_BOARD }}
+
+      - name: Add issue or PR to project board
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/orgs/${{ github.repository_owner }}/projects/${{ env.BOARD_NUMBER }}
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Assign PR to creator
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          gh pr edit $PR --add-assignee $AUTHOR --repo $REPO
+        env:
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -9,7 +9,32 @@ on:
 permissions: read-all
 
 jobs:
-  build-website:
-    uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
-    secrets:
-      netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+  build-deploy:
+    runs-on: ubuntu-latest
+    # Stop builds from running more than one at a time, to save resources and also
+    # to limit conflicts when uploading to the hosting provider.
+    concurrency:
+      group: build-website-group
+      cancel-in-progress: true
+    steps:
+      # This is a useful security step to check for unexpected outbound calls from the runner,
+      # which could indicate a compromised token or runner.
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Spell check repo
+        uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06 # v1.40.0
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+
+      - name: Render and publish to Netlify
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        with:
+          target: netlify
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,7 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: "Security: Dependency Review"
+
 on: pull_request
 
 # Limit token permissions for security
@@ -14,4 +15,15 @@ permissions: read-all
 
 jobs:
   dependency-review:
-    uses: seedcase-project/.github/.github/workflows/reusable-dependency-review.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: "Checkout Repository"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2

--- a/.github/workflows/release-project.yml
+++ b/.github/workflows/release-project.yml
@@ -9,13 +9,64 @@ on:
 permissions: read-all
 
 jobs:
-  release-project:
-    # This job outputs env variables `previous_version` and `current_version`.
-    # The workflow needs write permissions for `GITHUB_TOKEN` to create a release.
-    permissions:
-      contents: write
-    uses: seedcase-project/.github/.github/workflows/reusable-release-project.yml@main
-    with:
-      app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
-    secrets:
-      update-version-gh-token: ${{ secrets.UPDATE_VERSION_TOKEN }}
+  release:
+    if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
+    runs-on: ubuntu-latest
+    # Can only release one version at a time, so need to stop any other jobs that
+    # are also trying to release, to prevent conflicts.
+    concurrency:
+      group: release-project-group
+      cancel-in-progress: true
+    # Outputs for potential next jobs.
+    outputs:
+      previous_version: ${{ steps.version-var.outputs.previous_version }}
+      current_version: ${{ steps.version-var.outputs.current_version }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
+          private-key: ${{ secrets.UPDATE_VERSION_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # Only need the last commit from the repo.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set bot user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # This step outputs `REVISION` and `PREVIOUS_REVISION` env variables.
+      - id: cz
+        name: Update version and changelog
+        uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d # 0.26.0
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          changelog: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        if: ${{ env.PREVIOUS_REVISION != env.REVISION }}
+        with:
+          generate_release_notes: true
+          # env variable containing the new version, created by the Commitizen action
+          tag_name: ${{ env.REVISION }}
+          # To help with preventing random updates to existing releases.
+          overwrite_files: false
+          append_body: false
+
+      # Need to output this to tell any potential next job that a release was made.
+      - id: version-var
+        name: Output version variable
+        run: |
+          echo "previous_version=$PREVIOUS_REVISION" >> "$GITHUB_OUTPUT"
+          echo "current_version=$REVISION" >> "$GITHUB_OUTPUT"

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ update-template:
       template/complete/tools/
     cp -f .github/dependabot.yml .github/pull_request_template.md \
       template/complete/.github/
-    cp -f .github/workflows/release-project.yml .github/workflows/dependency-review.yml \
+    cp -f .github/workflows/dependency-review.yml \
       template/complete/.github/workflows/
 
 # Check the commit messages on the current branch that are not on the main branch

--- a/template/complete/.github/workflows/add-to-project.yml.jinja
+++ b/template/complete/.github/workflows/add-to-project.yml.jinja
@@ -14,14 +14,45 @@ on:
 # Limit token permissions for security
 permissions: read-all
 
+env:
+  ADD_TO_BOARD_APP_ID: {{ '${{ vars.ADD_TO_BOARD_APP_ID }}' }}
+  BOARD_NUMBER: {{ github_board_number }}
+
 jobs:
   add-to-project:
-    uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    with:
-      app-id: {{ '${{ vars.ADD_TO_BOARD_APP_ID }}' }}
-      board-number: {{ github_board_number }}
-    secrets:
-      add-to-board-token: {{ '${{ secrets.ADD_TO_BOARD }}' }}
-      gh-token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+    steps:
+      # This is a useful security step to check for unexpected outbound calls from the runner,
+      # which could indicate a compromised token or runner.
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      # Using this security pattern for GitHub Apps is recommended by GitHub and ensures that
+      # the token is only available for a short time and has limited permissions. Check out
+      # <https://guidebook.seedcase-project.org/operations/security> for more details.
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: {{ '${{ env.ADD_TO_BOARD_APP_ID }}' }}
+          # TODO: Confirm this is set up for the repo.
+          private-key: {{ '${{ secrets.ADD_TO_BOARD }}' }}
+
+      - name: Add issue or PR to project board
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/orgs/{{ '${{ github.repository_owner }}' }}/projects/{{ '${{ env.BOARD_NUMBER }}' }}
+          github-token: {{ '${{ steps.app-token.outputs.token }}' }}
+
+      - name: Assign PR to creator
+        if: {{ '${{ github.event_name == "pull_request" }}' }}
+        run: |
+          gh pr edit $PR --add-assignee $AUTHOR --repo $REPO
+        env:
+          REPO: {{ '${{ github.repository }}' }}
+          AUTHOR: {{ '${{ github.event.pull_request.user.login }}' }}
+          PR: {{ '${{ github.event.pull_request.html_url }}' }}
+          GH_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}

--- a/template/complete/.github/workflows/build-website.yml.jinja
+++ b/template/complete/.github/workflows/build-website.yml.jinja
@@ -8,19 +8,65 @@ on:
 # Limit token permissions for security
 permissions: read-all
 
+env:
+  # TODO: Set to true if building a website with PDF rendering.
+  USE_TINYTEX: false
+
 jobs:
-  build-website:
-    uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
+  build-deploy:
+    runs-on: ubuntu-latest
+    # Stop builds from running more than one at a time, to save resources and also
+    # to limit conflicts when uploading to the hosting provider.
+    concurrency:
+      group: build-website-group
+      cancel-in-progress: true
     {%- if hosting_provider == 'gh-pages' %}
-    with:
-      hosting-provider: gh-pages
+    # Needs these permissions to publish to GitHub Pages.
     permissions:
       contents: write
       pages: write
     {%- endif %}
-    secrets:
-      {%- if hosting_provider == 'gh-pages' %}
-      github-token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
-      {%- elif hosting_provider == 'netlify' %}
-      netlify-token: {{ '${{ secrets.NETLIFY_AUTH_TOKEN }}' }}
+    steps:
+      # This is a useful security step to check for unexpected outbound calls from the runner,
+      # which could indicate a compromised token or runner.
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Spell check repo
+        uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06 # v1.40.0
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        # Use basic token to avoid rate limiting when downloading tinytex, which uses GitHub API.
+        env:
+          GH_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+        with:
+          tinytex: {{ '${{ env.USE_TINYTEX }}' }}
+
+      - name: Install Chrome for PDF rendering
+        if: {{ '${{ env.USE_TINYTEX }}' }}
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt install ./google-chrome-stable_current_amd64.deb
+
+      {% if hosting_provider == 'netlify' -%}
+      - name: Render and publish to Netlify
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        with:
+          target: netlify
+          # TODO: Confirm this token is available for the repo.
+          NETLIFY_AUTH_TOKEN: {{ '${{ secrets.NETLIFY_AUTH_TOKEN }}' }}
+      {%- elif hosting_provider == 'gh-pages' -%}
+      # NOTE: Needs the contents and pages write permissions (used above).
+      - name: Render and publish to GitHub Pages
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
       {%- endif %}

--- a/template/complete/.github/workflows/dependency-review.yml
+++ b/template/complete/.github/workflows/dependency-review.yml
@@ -7,6 +7,7 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: "Security: Dependency Review"
+
 on: pull_request
 
 # Limit token permissions for security
@@ -14,4 +15,15 @@ permissions: read-all
 
 jobs:
   dependency-review:
-    uses: seedcase-project/.github/.github/workflows/reusable-dependency-review.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: "Checkout Repository"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2

--- a/template/complete/.github/workflows/release-project.yml
+++ b/template/complete/.github/workflows/release-project.yml
@@ -9,13 +9,71 @@ on:
 permissions: read-all
 
 jobs:
-  release-project:
-    # This job outputs env variables `previous_version` and `current_version`.
-    # The workflow needs write permissions for `GITHUB_TOKEN` to create a release.
-    permissions:
-      contents: write
-    uses: seedcase-project/.github/.github/workflows/reusable-release-project.yml@main
-    with:
-      app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
-    secrets:
-      update-version-gh-token: ${{ secrets.UPDATE_VERSION_TOKEN }}
+  release:
+    if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
+    runs-on: ubuntu-latest
+    # Can only release one version at a time, so need to stop any other jobs that
+    # are also trying to release, to prevent conflicts.
+    concurrency:
+      group: release-project-group
+      cancel-in-progress: true
+    # Outputs for potential next jobs.
+    outputs:
+      previous_version: ${{ steps.version-var.outputs.previous_version }}
+      current_version: ${{ steps.version-var.outputs.current_version }}
+    steps:
+      # This is a useful security step to check for unexpected outbound calls from the runner,
+      # which could indicate a compromised token or runner.
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      # Using this security pattern for GitHub Apps is recommended by GitHub and ensures that
+      # the token is only available for a short time and has limited permissions. Check out
+      # <https://guidebook.seedcase-project.org/operations/security> for more details.
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          # TODO: Confirm this is set up for the repo.
+          app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
+          # TODO: Confirm this is set up for the repo.
+          private-key: ${{ secrets.UPDATE_VERSION_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # Only need the last commit from the repo.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set bot user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # This step outputs `REVISION` and `PREVIOUS_REVISION` env variables.
+      - id: cz
+        name: Update version and changelog
+        uses: commitizen-tools/commitizen-action@bb4f1df6601e2a1a891506581b0c53acdc88e07d # 0.26.0
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          changelog: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        if: ${{ env.PREVIOUS_REVISION != env.REVISION }}
+        with:
+          generate_release_notes: true
+          # env variable containing the new version, created by the Commitizen action
+          tag_name: ${{ env.REVISION }}
+          # To help with preventing random updates to existing releases.
+          overwrite_files: false
+          append_body: false
+
+      # Need to output this to tell any potential next job that a release was made.
+      - id: version-var
+        name: Output version variable
+        run: |
+          echo "previous_version=$PREVIOUS_REVISION" >> "$GITHUB_OUTPUT"
+          echo "current_version=$REVISION" >> "$GITHUB_OUTPUT"

--- a/template/simple/.github/workflows/build-website.yml.jinja
+++ b/template/simple/.github/workflows/build-website.yml.jinja
@@ -9,18 +9,45 @@ on:
 permissions: read-all
 
 jobs:
-  build-website:
-    uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
-    {%- if hosting_provider == 'gh-pages' %}
-    with:
-      hosting-provider: gh-pages
+  build-deploy:
+    runs-on: ubuntu-latest
+    # Stop builds from running more than one at a time, to save resources and also
+    # to limit conflicts when uploading to the hosting provider.
+    concurrency:
+      group: build-website-group
+      cancel-in-progress: true
+    {% if hosting_provider == 'gh-pages' -%}
     permissions:
       contents: write
       pages: write
     {%- endif %}
-    secrets:
-      {%- if hosting_provider == 'gh-pages' %}
-      github-token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
-      {%- elif hosting_provider == 'netlify' %}
-      netlify-token: {{ '${{ secrets.NETLIFY_AUTH_TOKEN }}' }}
+    steps:
+      # This is a useful security step to check for unexpected outbound calls from the runner,
+      # which could indicate a compromised token or runner.
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+
+      {% if hosting_provider == 'netlify' -%}
+      - name: Render and publish to Netlify
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        with:
+          target: netlify
+          # TODO: Confirm this token is available for the repo.
+          NETLIFY_AUTH_TOKEN: {{ '${{ secrets.NETLIFY_AUTH_TOKEN }}' }}
+      {%- elif hosting_provider == 'gh-pages' -%}
+      # NOTE: Needs the contents and pages write permissions (used above).
+      - name: Render and publish to GitHub Pages
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
       {%- endif %}


### PR DESCRIPTION
# Description

Reusable workflows were useful when we had the original sync'ing process. But with templates, having the full workflow is easy to keep updated with those repos using the template. Plus, having the plain workflows included rather than reusable ones gives more autonomy to repos using the template. And it makes security scanners correctly scan the actions (reusable workflows are harder to scan).

Needs no review.

## Checklist

- [x] Ran `just run-all`
