### PR TITLE
fix: :construction_worker: release workflow needs write permission for release notes

### DIFF
--- a/.github/workflows/release-project.yml
+++ b/.github/workflows/release-project.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
     runs-on: ubuntu-latest
+    # To generate release notes, this job needs write access to the repository contents.
+    permissions:
+      contents: write
     # Can only release one version at a time, so need to stop any other jobs that
     # are also trying to release, to prevent conflicts.
     concurrency:

--- a/template/complete/.github/workflows/release-project.yml
+++ b/template/complete/.github/workflows/release-project.yml
@@ -11,6 +11,9 @@ permissions: read-all
 jobs:
   release:
     if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
+    # To generate release notes, this job needs write access to the repository contents.
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     # Can only release one version at a time, so need to stop any other jobs that
     # are also trying to release, to prevent conflicts.


### PR DESCRIPTION
# Description

Accidentally removed this as I moved the stuff over from the reusable workflows.

Needs no review.

## Checklist

- [x] Ran `just run-all`
