### PR TITLE
refactor: 🔥 no longer use Conventional Commit scopes

### DIFF
--- a/template/complete/.github/dependabot.yml
+++ b/template/complete/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: monthly
     commit-message:
       prefix: ci
-      include: scope

--- a/template/complete/.pre-commit-config.yaml
+++ b/template/complete/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
-  autofix_commit_msg: "chore(pre-commit): :pencil2: automatic fixes"
-  autoupdate_commit_msg: "ci(pre-commit): :construction_worker: update pre-commit CI version"
+  autofix_commit_msg: "chore: ✏️ automatic pre-commit hook fixes"
+  autoupdate_commit_msg: "ci: 👷 update pre-commit CI version"
 
 repos:
   - repo: https://github.com/gitleaks/gitleaks

--- a/template/complete/.vscode/settings.json
+++ b/template/complete/.vscode/settings.json
@@ -20,4 +20,6 @@
   ],
   "conventional-branch.format": "{Type}/{Branch}",
   "files.insertFinalNewline": true,
+  "conventionalCommits.emojiFormat": "emoji",
+  "conventionalCommits.promptScopes": false
 }


### PR DESCRIPTION
# Description

Since we don't really use them, nor do they provide much benefit for us. So we just removed them.

Needs no review.

## Checklist

- [x] Ran `just run-all`
