### PR TITLE
fix: 🔥 don't need references to Jinja in justfile

### DIFF
--- a/template/complete/justfile.jinja
+++ b/template/complete/justfile.jinja
@@ -39,15 +39,13 @@ check-spelling:
 check-urls:
   lychee . \
     --verbose \
-    --extensions md,qmd,jinja \
+    --extensions md,qmd \
     --exclude-path "_badges.qmd"
 
 # Format Markdown files
 format-md:
   # Use both rumdl and panache, for different purposes
   uvx rumdl fmt --silent
-  # `includes` option doesn't work with Jinja files, so do manually
-  uvx rumdl fmt --silent **/*.qmd.jinja **/*.md.jinja
   uvx --from panache-cli panache format . --quiet
 
 # Re-build the README file from the Quarto version


### PR DESCRIPTION
# Description

The Quarto website doesn't have Jinja files, I forgot to remove this after updating from the root justfile.

Needs no review.

## Checklist

- [x] Ran `just run-all`
