### PR TITLE
fix: 🐛 switch to single quotes, GitHub workflows can't use double

### DIFF
--- a/template/complete/.github/workflows/add-to-project.yml.jinja
+++ b/template/complete/.github/workflows/add-to-project.yml.jinja
@@ -49,7 +49,7 @@ jobs:
           github-token: {{ '${{ steps.app-token.outputs.token }}' }}
 
       - name: Assign PR to creator
-        if: {{ '${{ github.event_name == "pull_request" }}' }}
+        if: {{ "${{ github.event_name == 'pull_request' }}" }}
         run: |
           gh pr edit $PR --add-assignee $AUTHOR --repo $REPO
         env:


### PR DESCRIPTION
# Description

Very unexpected bug, GHA can only use single quotes, not double.

Needs no review.

## Checklist

- [x] Ran `just run-all`
