### PR TITLE
fix: 🐛 ignore GitHub in URL checker as it often gets blocked

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,6 +57,7 @@ check-urls:
   lychee . \
     --verbose \
     --extensions md,qmd,jinja \
+    --exclude "github\.com" \
     --exclude-path "_badges.qmd"
 
 # Format Markdown files

--- a/template/complete/justfile.jinja
+++ b/template/complete/justfile.jinja
@@ -40,6 +40,7 @@ check-urls:
   lychee . \
     --verbose \
     --extensions md,qmd \
+    --exclude "github\.com" \
     --exclude-path "_badges.qmd"
 
 # Format Markdown files
@@ -62,7 +63,7 @@ build-website:
 
 # Preview the website with automatic reload on changes
 preview-website:
-  quarto preview
+  uvx --from quarto quarto preview
 
 # Check for and apply updates from the template
 update-from-template:


### PR DESCRIPTION
# Description

Lychee often gets blocked by GitHub, unless it is given a (read-only) token.

Needs no review.

## Checklist

- [x] Ran `just run-all`
