### PR TITLE
fix: 🐛 escape `{{ version }}` tag in `cog.toml` so Jinja leaves it

### DIFF
--- a/template/complete/.config/{% if for_seedcase %}cog.toml{% endif %}.jinja
+++ b/template/complete/.config/{% if for_seedcase %}cog.toml{% endif %}.jinja
@@ -4,9 +4,9 @@ disable_bump_commit = true
 branch_whitelist = ["main"]
 pre_bump_hooks = [
   # Quiet the log output of git-cliff, it is noisy.
-  "RUST_LOG='none' uvx git-cliff --tag {{version}}",
+  "RUST_LOG='none' uvx git-cliff --tag {{ '{{ version }}' }}",
   "uvx --from panache-cli panache format CHANGELOG.md --quiet",
-  "git commit CHANGELOG.md -m 'build: 🔖 update version to {{version}} [skip ci]'",
+  "git commit CHANGELOG.md -m 'build: 🔖 update version to {{ '{{ version }}' }} [skip ci]'",
 ]
 post_bump_hooks = ["git push", "git push --tags"]
 


### PR DESCRIPTION
# Description

Jinja stripped this tag, so needs to be escaped.

Needs no review.

## Checklist

- [x] Ran `just run-all`
