### PR TITLE
fix: 🐛 remove spaces in `{{}}` in `cog.toml`, it doesn't allow them

### DIFF
--- a/template/complete/.config/{% if for_seedcase %}cog.toml{% endif %}.jinja
+++ b/template/complete/.config/{% if for_seedcase %}cog.toml{% endif %}.jinja
@@ -4,9 +4,9 @@ disable_bump_commit = true
 branch_whitelist = ["main"]
 pre_bump_hooks = [
   # Quiet the log output of git-cliff, it is noisy.
-  "RUST_LOG='none' uvx git-cliff --tag {{ '{{ version }}' }}",
+  "RUST_LOG='none' uvx git-cliff --tag {{ '{{version}}' }}",
   "uvx --from panache-cli panache format CHANGELOG.md --quiet",
-  "git commit CHANGELOG.md -m 'build: 🔖 update version to {{ '{{ version }}' }} [skip ci]'",
+  "git commit CHANGELOG.md -m 'build: 🔖 update version to {{ '{{version}}' }} [skip ci]'",
 ]
 post_bump_hooks = ["git push", "git push --tags"]
 

--- a/template/complete/CONTRIBUTING.md.jinja
+++ b/template/complete/CONTRIBUTING.md.jinja
@@ -49,9 +49,9 @@ Git messages. Using this convention allows us to be able to automatically create
 a release based on the commit message by using
 [Cocogitto](https://decisions.seedcase-project.org/why-semantic-release-with-cocogitto/).
 If you don't use Conventional Commits when making a commit, we will revise the
-pull request title to follow that format. That's because we squash merge when merging
-pull requests, so all other commits in the pull request will be squashed into
-one commit.
+pull request title to follow that format. That's because we squash merge when
+merging pull requests, so all other commits in the pull request will be squashed
+into one commit.
 
 ## :file_folder: Explanation of files and folders
 


### PR DESCRIPTION
# Description

`{{ version }}` fails, but `{{version}}` doesn't fail when running cog (Cocogitto).

Needs no review.

## Checklist

- [x] Ran `just run-all`
